### PR TITLE
Add tests for column helpers and output widget

### DIFF
--- a/tests/testthat/test-columns.R
+++ b/tests/testthat/test-columns.R
@@ -1,0 +1,21 @@
+library(tabulatoR)
+
+# Tests for Column
+
+test_that("Column returns expected list", {
+  expected <- list(list(title = "Name", field = "name", visible = TRUE, editable = FALSE))
+  expect_equal(Column("Name", "name"), expected)
+})
+
+# Tests for ActionColumn
+
+test_that("ActionColumn returns expected list", {
+  js_code <- glue::glue(
+    "\n  function(cell, formatterParams, onRendered) {\n    const el = cell.getElement();\n    const Button = document.createElement('button');\n    Button.textContent = 'Edit';\n    Button.className = 'btn btn-primary';\n    Button.onclick = function() {\n      const table = cell.getTable();\n      const inputId = table.id;\n      const inputVal = Shiny.shinyapp.$inputValues[inputId] || {};\n      inputVal['edit'] = {\n        event: 'edit',\n        field: cell.getField(),\n        value: flattenData(cell.getValue()),\n        row: flattenData(cell.getRow().getData()),\n        position: flattenData(cell.getRow().getPosition())\n      };\n      Shiny.setInputValue(inputId, inputVal, { priority: 'event' });\n    };\n    el.appendChild(Button);\n  }\n  ", .open = "<<", .close = ">>")
+  expected <- Column(
+    title = "Edit",
+    field = "edit",
+    formatter = htmlwidgets::JS(js_code)
+  )
+  expect_equal(ActionColumn("Edit", "edit"), expected)
+})

--- a/tests/testthat/test-output.R
+++ b/tests/testthat/test-output.R
@@ -1,0 +1,15 @@
+library(tabulatoR)
+
+test_that("tabulatoROutput creates a div with correct attributes and dependencies", {
+  tag <- tabulatoROutput("test-id", width = "50%", height = "300px")
+  div <- tag[[2]]
+  expect_equal(div$name, "div")
+  expect_equal(div$attribs$id, "test-id")
+  expect_equal(div$attribs$width, "50%")
+  expect_equal(div$attribs$height, "300px")
+  expect_true("tabulator-output" %in% div$attribs$class)
+
+  rendered <- htmltools::renderTags(tag)$head
+  expect_true(grepl("tabulator.min.css", rendered))
+  expect_true(grepl("tabulator.min.js", rendered))
+})


### PR DESCRIPTION
## Summary
- add tests for Column and ActionColumn helper functions
- add tests ensuring tabulatoROutput builds div with correct attributes and dependencies

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"`


------
https://chatgpt.com/codex/tasks/task_e_689bf8af272483269b56f9263e78b25a