### PR TITLE
Add snapshot test for renderTabulatoR

### DIFF
--- a/tests/testthat/_snaps/render.md
+++ b/tests/testthat/_snaps/render.md
@@ -1,0 +1,43 @@
+# renderTabulatoR generates expected payload
+
+    Code
+      jsonlite::prettify(x)
+    Output
+      {
+          "options": {
+              "data": [
+                  {
+                      "a": [
+                          1
+                      ],
+                      "b": [
+                          "x"
+                      ]
+                  },
+                  {
+                      "a": [
+                          2
+                      ],
+                      "b": [
+                          "y"
+                      ]
+                  }
+              ],
+              "columns": [
+                  {
+                      "title": "a",
+                      "field": "a",
+                      "editor": true
+                  },
+                  {
+                      "title": "b",
+                      "field": "b",
+                      "editor": true
+                  }
+              ],
+              "layout": "fitColumns"
+          },
+          "events": null
+      }
+       
+

--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -1,0 +1,15 @@
+library(shiny)
+
+expect_snapshot_json <- function(x) {
+  testthat::expect_snapshot(jsonlite::prettify(x))
+}
+
+test_that("renderTabulatoR generates expected payload", {
+  session <- shiny::MockShinySession$new()
+  shiny::withReactiveDomain(session, {
+    rv <- reactiveVal(data.frame(a = 1:2, b = c("x", "y")))
+    render_fun <- renderTabulatoR(rv())
+    json <- shiny::isolate(render_fun())
+    expect_snapshot_json(json)
+  })
+})


### PR DESCRIPTION
## Summary
- add snapshot test for `renderTabulatoR`

## Testing
- `R -q -e 'testthat::test_local()'`


------
https://chatgpt.com/codex/tasks/task_e_689bf8bf770483269898ac7046520a1e