### PR TITLE
Add shinytest2 regression test

### DIFF
--- a/tests/testthat/_snaps/app/001.json
+++ b/tests/testthat/_snaps/app/001.json
@@ -1,0 +1,25 @@
+{
+    "input": {
+        "table": {
+            "action": "cellEdited",
+            "field": "mpg",
+            "value": 99,
+            "old_value": 21,
+            "row": {
+                "mpg": 99,
+                "cyl": 6,
+                "disp": 160,
+                "hp": 110,
+                "drat": 3.9,
+                "wt": 2.62,
+                "qsec": 16.46,
+                "vs": 0,
+                "am": 1,
+                "gear": 4,
+                "carb": 4,
+                "id": 1
+            },
+            "index": 0
+        }
+    }
+}

--- a/tests/testthat/_snaps/app/002.json
+++ b/tests/testthat/_snaps/app/002.json
@@ -1,0 +1,12 @@
+{
+    "input": {
+        "table": {
+            "action": "rowAdded",
+            "row": {
+                "id": 1000,
+                "mpg": 30,
+                "cyl": 4
+            }
+        }
+    }
+}

--- a/tests/testthat/_snaps/app/003.json
+++ b/tests/testthat/_snaps/app/003.json
@@ -1,0 +1,21 @@
+{
+    "input": {
+        "table": {
+            "action": "rowDeleted",
+            "row": {
+                "mpg": 99,
+                "cyl": 6,
+                "disp": 160,
+                "hp": 110,
+                "drat": 3.9,
+                "wt": 2.62,
+                "qsec": 16.46,
+                "vs": 0,
+                "am": 1,
+                "gear": 4,
+                "carb": 4,
+                "id": 1
+            }
+        }
+    }
+}

--- a/tests/testthat/test-app.R
+++ b/tests/testthat/test-app.R
@@ -1,0 +1,22 @@
+library(shinytest2)
+
+app <- AppDriver$new(
+    app_dir = testthat::test_path(".."),
+    name = "app",
+    variant = platform_variant(),
+    seed = 123
+)
+
+app$wait_for_js("window.table !== undefined")
+
+app$run_js("window.table.getRows()[0].getCell('mpg').setValue(99);")
+app$wait_for_value(input = "table")
+app$expect_values(input = "table", screenshot = FALSE)
+
+app$run_js("window.table.addData([{id: 1000, mpg: 30, cyl: 4}]);")
+app$wait_for_value(input = "table")
+app$expect_values(input = "table", screenshot = FALSE)
+
+app$run_js("window.table.getRows()[0].delete();")
+app$wait_for_value(input = "table")
+app$expect_values(input = "table", screenshot = FALSE)


### PR DESCRIPTION
## Summary
- add shinytest2 regression test covering cell edits and row updates

## Testing
- `R -q -e "parse('tests/testthat/test-app.R')"`


------
https://chatgpt.com/codex/tasks/task_e_689bfb5ba00883268f57f66b1aba6b3a