### PR TITLE
Add test coverage for proxy functions

### DIFF
--- a/tests/testthat/test-proxy.R
+++ b/tests/testthat/test-proxy.R
@@ -1,0 +1,58 @@
+test_that("tabulatorReplaceData sends correct custom message", {
+    session <- shiny::MockShinySession$new()
+    messages <- list()
+    session$sendCustomMessage <- function(type, message) {
+        messages[[type]] <<- message
+    }
+    data <- data.frame(a = 1:2, b = c("x", "y"))
+    tabulatorReplaceData("my_id", data, session)
+    expected_data <- unname(split(data, seq(nrow(data))))
+    expect_equal(
+        messages[["tabulator-replace-data"]],
+        list(id = "my_id", data = expected_data)
+    )
+})
+
+
+test_that("tabulatorAddData sends correct custom message", {
+    session <- shiny::MockShinySession$new()
+    messages <- list()
+    session$sendCustomMessage <- function(type, message) {
+        messages[[type]] <<- message
+    }
+    data <- data.frame(a = 3:4)
+    tabulatorAddData("tbl", data, add_to = "bottom", session = session)
+    expected_data <- unname(split(data, seq(nrow(data))))
+    expect_equal(
+        messages[["tabulator-add-data"]],
+        list(id = "tbl", data = expected_data, addToTop = FALSE)
+    )
+})
+
+
+test_that("tabulatorRemoveRow sends correct custom message", {
+    session <- shiny::MockShinySession$new()
+    messages <- list()
+    session$sendCustomMessage <- function(type, message) {
+        messages[[type]] <<- message
+    }
+    tabulatorRemoveRow("tbl", 5, session)
+    expect_equal(
+        messages[["tabulator-remove-row"]],
+        list(id = "tbl", index = 5)
+    )
+})
+
+
+test_that("tabulatorRestoreOldValue sends correct custom message", {
+    session <- shiny::MockShinySession$new()
+    messages <- list()
+    session$sendCustomMessage <- function(type, message) {
+        messages[[type]] <<- message
+    }
+    tabulatorRestoreOldValue("tbl", 2, "field", session)
+    expect_equal(
+        messages[["tabulator-restore-old-value"]],
+        list(id = "tbl", index = 2, field = "field")
+    )
+})


### PR DESCRIPTION
## Summary
- add tests verifying custom message payloads for tabulator proxy helpers

## Testing
- `R -q -e "print('Tests not run as per instructions')"`


------
https://chatgpt.com/codex/tasks/task_e_689bfd86fd4083268f73fae9a9ed1c78