### PR TITLE
Use js helper instead of JS

### DIFF
--- a/R/columns.R
+++ b/R/columns.R
@@ -8,8 +8,8 @@
 #'
 #' @details
 #' For the full list of column options, see the [Tabulator documentation](https://tabulator.info/docs/6.3/columns#definition).
-#' JavaScript callbacks (such as `cellClick` or `formatter`) must be wrapped using `JS()`
-#' from the `htmlwidgets` package to be interpreted as executable functions in the browser.
+#' JavaScript callbacks (such as `cellClick` or `formatter`) must be wrapped using `js()`
+#' from this package to be interpreted as executable functions in the browser.
 #'
 #' @param title The column title to display in the table header.
 #' @param field The field name in the data corresponding to this column.
@@ -18,12 +18,12 @@
 #' @param width A fixed column width (e.g., "150px" or "20%").
 #' @param resizable Logical. Whether the user can resize this column.
 #' @param editable Logical. If `TRUE`, the cells are editable.
-#' @param editor Editor type (`"input"`, `"number"`, etc.) or JS function via `JS()`.
+#' @param editor Editor type (`"input"`, `"number"`, etc.) or JS function via `js()`.
 #' @param editorParams A list of parameters passed to the editor.
-#' @param formatter Formatter name or JS function (use `JS()`).
+#' @param formatter Formatter name or JS function (use `js()`).
 #' @param formatterParams A list of parameters passed to the formatter.
-#' @param cellClick JS function triggered when a cell is clicked (use `JS()`).
-#' @param cellEdited JS function triggered after a cell is edited (use `JS()`).
+#' @param cellClick JS function triggered when a cell is clicked (use `js()`).
+#' @param cellEdited JS function triggered after a cell is edited (use `js()`).
 #' @param ... Additional named Tabulator column options.
 #' @param .opts A named list of column options that can be reused programmatically.
 #'        Values in `...` will override matching keys in `.opts`.
@@ -80,7 +80,7 @@ Column <- function(
 #' The `ActionColumn` function creates a column with a button in each cell. When the button
 #' is clicked, it triggers a JavaScript action that can interact with Shiny inputs. The action
 #' is defined by the `action` parameter, which is inserted into the JavaScript code.
-#' JavaScript callbacks must be wrapped using `JS()` from the `htmlwidgets` package to be
+#' JavaScript callbacks must be wrapped using `js()` from this package to be
 #' interpreted as executable functions in the browser.
 #'
 #' @param text The text to display on the button in each cell.
@@ -117,7 +117,7 @@ ActionColumn <- function(text, action, class = 'btn btn-primary', ...) {
 Column(
   title = text,
   field = action,
-  formatter = JS(js_code),
+  formatter = js(js_code),
   ...
 )
 }

--- a/R/render.R
+++ b/R/render.R
@@ -23,8 +23,8 @@
 #' @param quoted Logical. Is `expr` already quoted? If not, it will be quoted.
 #'
 #' @details
-#' JavaScript callbacks (such as `cellClick` or `formatter`) must be wrapped using `JS()`
-#' from the `htmlwidgets` package to be interpreted as executable functions in the browser.
+#' JavaScript callbacks (such as `cellClick` or `formatter`) must be wrapped using `js()`
+#' from this package to be interpreted as executable functions in the browser.
 #' 
 #' @return A function that returns a list to be serialized and passed to the Tabulator output binding.
 #' @export

--- a/man/ActionColumn.Rd
+++ b/man/ActionColumn.Rd
@@ -28,6 +28,6 @@ in Shiny applications.
 The \code{ActionColumn} function creates a column with a button in each cell. When the button
 is clicked, it triggers a JavaScript action that can interact with Shiny inputs. The action
 is defined by the \code{action} parameter, which is inserted into the JavaScript code.
-JavaScript callbacks must be wrapped using \code{JS()} from the \code{htmlwidgets} package to be
+JavaScript callbacks must be wrapped using \code{js()} from this package to be
 interpreted as executable functions in the browser.
 }

--- a/man/Column.Rd
+++ b/man/Column.Rd
@@ -37,17 +37,17 @@ Column(
 
 \item{editable}{Logical. If \code{TRUE}, the cells are editable.}
 
-\item{editor}{Editor type (\code{"input"}, \code{"number"}, etc.) or JS function via \code{JS()}.}
+\item{editor}{Editor type (\code{"input"}, \code{"number"}, etc.) or JS function via \code{js()}.}
 
 \item{editorParams}{A list of parameters passed to the editor.}
 
-\item{formatter}{Formatter name or JS function (use \code{JS()}).}
+\item{formatter}{Formatter name or JS function (use \code{js()}).}
 
 \item{formatterParams}{A list of parameters passed to the formatter.}
 
-\item{cellClick}{JS function triggered when a cell is clicked (use \code{JS()}).}
+\item{cellClick}{JS function triggered when a cell is clicked (use \code{js()}).}
 
-\item{cellEdited}{JS function triggered after a cell is edited (use \code{JS()}).}
+\item{cellEdited}{JS function triggered after a cell is edited (use \code{js()}).}
 
 \item{...}{Additional named Tabulator column options.}
 
@@ -65,6 +65,6 @@ API via \code{...} or \code{.opts}.
 }
 \details{
 For the full list of column options, see the \href{https://tabulator.info/docs/6.3/columns#definition}{Tabulator documentation}.
-JavaScript callbacks (such as \code{cellClick} or \code{formatter}) must be wrapped using \code{JS()}
-from the \code{htmlwidgets} package to be interpreted as executable functions in the browser.
+JavaScript callbacks (such as \code{cellClick} or \code{formatter}) must be wrapped using \code{js()}
+from this package to be interpreted as executable functions in the browser.
 }

--- a/man/renderTabulatoR.Rd
+++ b/man/renderTabulatoR.Rd
@@ -54,6 +54,6 @@ Returns a function that outputs a JSON-serializable payload consumed by the
 custom tabulatoR JavaScript output binding.
 }
 \details{
-JavaScript callbacks (such as \code{cellClick} or \code{formatter}) must be wrapped using \code{JS()}
-from the \code{htmlwidgets} package to be interpreted as executable functions in the browser.
+JavaScript callbacks (such as \code{cellClick} or \code{formatter}) must be wrapped using \code{js()}
+from this package to be interpreted as executable functions in the browser.
 }

--- a/tests/testthat/test-columns.R
+++ b/tests/testthat/test-columns.R
@@ -15,7 +15,7 @@ test_that("ActionColumn returns expected list", {
   expected <- Column(
     title = "Edit",
     field = "edit",
-    formatter = htmlwidgets::JS(js_code)
+    formatter = js(js_code)
   )
   expect_equal(ActionColumn("Edit", "edit"), expected)
 })

--- a/tests/testthat/test-events.R
+++ b/tests/testthat/test-events.R
@@ -19,7 +19,7 @@ test_that("renderTabulatoR serializes custom event handlers", {
     shiny::withReactiveDomain(session, {
         rv <- reactiveVal(data.frame(a = 1))
         custom <- renderTabulatoR(rv(), events = list(
-            cellClick = htmlwidgets::JS("function(){ return { action: 'custom' }; }")
+            cellClick = js("function(){ return { action: 'custom' }; }")
         ))
         json <- shiny::isolate(custom())
         payload <- jsonlite::fromJSON(json)


### PR DESCRIPTION
## Summary
- Replace references to `JS()` with `js()` in rendering and column helpers.
- Update ActionColumn to use `js()` and refresh documentation accordingly.
- Adjust tests to expect `js()` functions.

## Testing
- `R -q -e 'devtools::document()'` *(fails: there is no package called 'devtools')*
- `R -q -e 'testthat::test_dir("tests/testthat")'` *(fails: there is no package called 'testthat')*

------
https://chatgpt.com/codex/tasks/task_e_689c01ab693483268599552c9fc4349c