### PR TITLE
Remove unused variables from Tabulator output binding

### DIFF
--- a/inst/tabulatoR.js
+++ b/inst/tabulatoR.js
@@ -188,10 +188,7 @@ const defaultEventHandlers = {
             window[el.id] = table;
             
             // Attach event listeners to Tabulator events
-            const inputId = el.id;
-            
-            const eventCache = {};
-            
+
             // Default events if none were provided
             const userEvents = payload.events || {};
             const mergedEvents = { ...defaultEventHandlers, ...userEvents };


### PR DESCRIPTION
## Summary
- drop unused inputId and eventCache variables in renderValue
- verify no remaining references to removed variables

## Testing
- `npx --yes eslint@8 inst/tabulatoR.js --no-eslintrc --rule "no-unused-vars:error" --parser-options=ecmaVersion:2020 --format json`
- `R -q -e 'testthat::test_dir("tests/testthat", reporter = "summary")'` *(fails: there is no package called 'testthat')*

------
https://chatgpt.com/codex/tasks/task_e_689c045bb1888326be8bd06bb882e084