### PR TITLE
Flatten event payloads before sending to Shiny

### DIFF
--- a/inst/tabulatoR.js
+++ b/inst/tabulatoR.js
@@ -208,9 +208,9 @@ const defaultEventHandlers = {
                     const payload = typeof handler === "function"
                     ? handler(...args)
                     : { [eventName]: { args } };
-                    
+
                     // Explicitly set only the latest event (no merge!)
-                    Shiny.setInputValue(el.id, payload, { priority: "event" });
+                    Shiny.setInputValue(el.id, flattenData(payload), { priority: "event" });
                 });
             });
 

--- a/tests/custom-handler-app/app.R
+++ b/tests/custom-handler-app/app.R
@@ -1,0 +1,17 @@
+library(shiny)
+devtools::load_all()
+
+ui <- fluidPage(
+    tabulatoROutput("tbl")
+)
+
+server <- function(input, output, session) {
+    output$tbl <- renderTabulatoR(
+        data.frame(a = 1),
+        events = list(
+            cellClick = js("\n                function(e, cell){\n                    return { action: 'cellClick', nested: [[cell.getValue()]] };\n                }\n            ")
+        )
+    )
+}
+
+shinyApp(ui, server)


### PR DESCRIPTION
## Summary
- Wrap user and default event payloads with `flattenData` before updating Shiny inputs
- Add regression test using a custom handler that omits `flattenData`
- Include minimal Shiny app for the new test

## Testing
- `R -q -e "pkgload::load_all(); testthat::test_dir('tests/testthat')"` *(failed: ActionColumn tests and others)*

------
https://chatgpt.com/codex/tasks/task_e_689c0e2055e88326a2e40b5f56518ee4