### PR TITLE
Convert ActionColumn tests to snapshots

### DIFF
--- a/tests/testthat/_snaps/columns.md
+++ b/tests/testthat/_snaps/columns.md
@@ -1,0 +1,50 @@
+# ActionColumn returns expected list
+
+    Code
+      ActionColumn("Edit", "edit")
+    Output
+      [[1]]
+      [[1]]$title
+      [1] "Edit"
+      
+      [[1]]$field
+      [1] "edit"
+      
+      [[1]]$visible
+      [1] TRUE
+      
+      [[1]]$editable
+      [1] FALSE
+      
+      [[1]]$formatter
+      [1] "<js>function(cell, formatterParams, onRendered) {\n  const el = cell.getElement();\n  const Button = document.createElement('button');\n  Button.className = \"btn btn-primary\";\n  Button.innerHTML = \"Edit\";\n  Button.onclick = function() {\n    const table = cell.getTable();\n    const inputId = table.id;\n    const inputVal = Shiny.shinyapp.$inputValues[inputId] || {};\n    inputVal[\"edit\"] = {\n      event: \"edit\",\n      field: cell.getField(),\n      value: flattenData(cell.getValue()),\n      row: flattenData(cell.getRow().getData()),\n      position: flattenData(cell.getRow().getPosition())\n    };\n    Shiny.setInputValue(inputId, inputVal, { priority: 'event' });\n  };\n  el.appendChild(Button);\n}</js>"
+      attr(,"class")
+      [1] "tabulatoR_js"
+      
+      
+
+# ActionColumn supports icons
+
+    Code
+      ActionColumn("Edit", "edit", icon = shiny::icon("edit"))
+    Output
+      [[1]]
+      [[1]]$title
+      [1] "Edit"
+      
+      [[1]]$field
+      [1] "edit"
+      
+      [[1]]$visible
+      [1] TRUE
+      
+      [[1]]$editable
+      [1] FALSE
+      
+      [[1]]$formatter
+      [1] "<js>function(cell, formatterParams, onRendered) {\n  const el = cell.getElement();\n  const Button = document.createElement('button');\n  Button.className = \"btn btn-primary\";\n  Button.innerHTML = \"<i class=\\\"far fa-pen-to-square\\\" role=\\\"presentation\\\" aria-label=\\\"pen-to-square icon\\\"><\\/i>Edit\";\n  Button.onclick = function() {\n    const table = cell.getTable();\n    const inputId = table.id;\n    const inputVal = Shiny.shinyapp.$inputValues[inputId] || {};\n    inputVal[\"edit\"] = {\n      event: \"edit\",\n      field: cell.getField(),\n      value: flattenData(cell.getValue()),\n      row: flattenData(cell.getRow().getData()),\n      position: flattenData(cell.getRow().getPosition())\n    };\n    Shiny.setInputValue(inputId, inputVal, { priority: 'event' });\n  };\n  el.appendChild(Button);\n}</js>"
+      attr(,"class")
+      [1] "tabulatoR_js"
+      
+      
+

--- a/tests/testthat/test-columns.R
+++ b/tests/testthat/test-columns.R
@@ -10,23 +10,9 @@ test_that("Column returns expected list", {
 # Tests for ActionColumn
 
 test_that("ActionColumn returns expected list", {
-  js_code <- glue::glue(
-    "\n  function(cell, formatterParams, onRendered) {\n    const el = cell.getElement();\n    const Button = document.createElement('button');\n    Button.className = 'btn btn-primary';\n    Button.innerHTML = 'Edit';\n    Button.onclick = function() {\n      const table = cell.getTable();\n      const inputId = table.id;\n      const inputVal = Shiny.shinyapp.$inputValues[inputId] || {};\n      inputVal['edit'] = {\n        event: 'edit',\n        field: cell.getField(),\n        value: flattenData(cell.getValue()),\n        row: flattenData(cell.getRow().getData()),\n        position: flattenData(cell.getRow().getPosition())\n      };\n      Shiny.setInputValue(inputId, inputVal, { priority: 'event' });\n    };\n    el.appendChild(Button);\n  }\n  ", .open = "<<", .close = ">>")
-  expected <- Column(
-    title = "Edit",
-    field = "edit",
-    formatter = js(js_code)
-  )
-  expect_equal(ActionColumn("Edit", "edit"), expected)
+  expect_snapshot(ActionColumn("Edit", "edit"))
 })
 
 test_that("ActionColumn supports icons", {
-  js_code <- glue::glue(
-    "\n  function(cell, formatterParams, onRendered) {\n    const el = cell.getElement();\n    const Button = document.createElement('button');\n    Button.className = 'btn btn-primary';\n    Button.innerHTML = '<i class=\"fa fa-edit\" role=\"presentation\" aria-hidden=\"true\"></i>Edit';\n    Button.onclick = function() {\n      const table = cell.getTable();\n      const inputId = table.id;\n      const inputVal = Shiny.shinyapp.$inputValues[inputId] || {};\n      inputVal['edit'] = {\n        event: 'edit',\n        field: cell.getField(),\n        value: flattenData(cell.getValue()),\n        row: flattenData(cell.getRow().getData()),\n        position: flattenData(cell.getRow().getPosition())\n      };\n      Shiny.setInputValue(inputId, inputVal, { priority: 'event' });\n    };\n    el.appendChild(Button);\n  }\n  ", .open = "<<", .close = ">>")
-  expected <- Column(
-    title = "Edit",
-    field = "edit",
-    formatter = js(js_code)
-  )
-  expect_equal(ActionColumn("Edit", "edit", icon = shiny::icon("edit")), expected)
+  expect_snapshot(ActionColumn("Edit", "edit", icon = shiny::icon("edit")))
 })


### PR DESCRIPTION
## Summary
- test: switch ActionColumn tests to `expect_snapshot`
- test: add snapshots for default and icon variants

## Testing
- `R -q -e "Sys.setenv(NOT_CRAN='true'); pkgload::load_all(); testthat::test_file('tests/testthat/test-columns.R')"`


------
https://chatgpt.com/codex/tasks/task_e_689c1323fc0c8326a8f39d9b3a491177