### PR TITLE
Use snapshot testing for proxy messages

### DIFF
--- a/tests/testthat/_snaps/proxy.md
+++ b/tests/testthat/_snaps/proxy.md
@@ -1,0 +1,68 @@
+# tabulatorReplaceData sends correct custom message
+
+    Code
+      messages[["tabulator-replace-data"]]
+    Output
+      $id
+      [1] "my_id"
+      
+      $data
+      $data[[1]]
+        a b
+      1 1 x
+      
+      $data[[2]]
+        a b
+      2 2 y
+      
+      
+
+# tabulatorAddData sends correct custom message
+
+    Code
+      messages[["tabulator-add-data"]]
+    Output
+      $id
+      [1] "tbl"
+      
+      $data
+      $data[[1]]
+        a
+      1 3
+      
+      $data[[2]]
+        a
+      2 4
+      
+      
+      $addToTop
+      [1] FALSE
+      
+
+# tabulatorRemoveRow sends correct custom message
+
+    Code
+      messages[["tabulator-remove-row"]]
+    Output
+      $id
+      [1] "tbl"
+      
+      $index
+      [1] 5
+      
+
+# tabulatorRestoreOldValue sends correct custom message
+
+    Code
+      messages[["tabulator-restore-old-value"]]
+    Output
+      $id
+      [1] "tbl"
+      
+      $index
+      [1] 2
+      
+      $field
+      [1] "field"
+      
+

--- a/tests/testthat/test-proxy.R
+++ b/tests/testthat/test-proxy.R
@@ -6,11 +6,7 @@ test_that("tabulatorReplaceData sends correct custom message", {
     }
     data <- data.frame(a = 1:2, b = c("x", "y"))
     tabulatorReplaceData("my_id", data, session)
-    expected_data <- unname(split(data, seq(nrow(data))))
-    expect_equal(
-        messages[["tabulator-replace-data"]],
-        list(id = "my_id", data = expected_data)
-    )
+    expect_snapshot(messages[["tabulator-replace-data"]])
 })
 
 
@@ -22,11 +18,7 @@ test_that("tabulatorAddData sends correct custom message", {
     }
     data <- data.frame(a = 3:4)
     tabulatorAddData("tbl", data, add_to = "bottom", session = session)
-    expected_data <- unname(split(data, seq(nrow(data))))
-    expect_equal(
-        messages[["tabulator-add-data"]],
-        list(id = "tbl", data = expected_data, addToTop = FALSE)
-    )
+    expect_snapshot(messages[["tabulator-add-data"]])
 })
 
 
@@ -37,10 +29,7 @@ test_that("tabulatorRemoveRow sends correct custom message", {
         messages[[type]] <<- message
     }
     tabulatorRemoveRow("tbl", 5, session)
-    expect_equal(
-        messages[["tabulator-remove-row"]],
-        list(id = "tbl", index = 5)
-    )
+    expect_snapshot(messages[["tabulator-remove-row"]])
 })
 
 
@@ -51,8 +40,5 @@ test_that("tabulatorRestoreOldValue sends correct custom message", {
         messages[[type]] <<- message
     }
     tabulatorRestoreOldValue("tbl", 2, "field", session)
-    expect_equal(
-        messages[["tabulator-restore-old-value"]],
-        list(id = "tbl", index = 2, field = "field")
-    )
+    expect_snapshot(messages[["tabulator-restore-old-value"]])
 })


### PR DESCRIPTION
## Summary
- switch proxy tests to `expect_snapshot` instead of explicit expected values
- add snapshot file for proxy message payloads

## Testing
- `NOT_CRAN=true R -q -e 'pkgload::load_all(); testthat::test_file("tests/testthat/test-proxy.R")'`


------
https://chatgpt.com/codex/tasks/task_e_689c131d8030832694cd562fa70609b7