### PR TITLE
Add static preview app

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,4 +15,6 @@ Imports:
     shiny
 Suggests: 
     testthat (>= 3.0.0)
+    shinytest2
 Config/testthat/edition: 3
+

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,7 @@
 export(ActionColumn)
 export(Column)
 export(js)
+export(preview_static)
 export(renderTabulatoR)
 export(tabulatoROutput)
 export(tabulatorAddData)

--- a/R/preview.R
+++ b/R/preview.R
@@ -1,0 +1,23 @@
+#' Preview a static Tabulator table
+#'
+#' Launches a minimal Shiny application showing a non-editable Tabulator table.
+#' This can be used to quickly preview the package output or within automated tests.
+#'
+#' @return A `shiny.appobj` object.
+#' @examples
+#' if (interactive()) {
+#'     preview_static()
+#' }
+#' @export
+preview_static <- function() {
+    ui <- shiny::fluidPage(
+        tabulatoROutput("static_table")
+    )
+
+    server <- function(input, output, session) {
+        output$static_table <- renderTabulatoR(head(mtcars), editable = FALSE)
+    }
+
+    shiny::shinyApp(ui, server)
+}
+

--- a/tests/testthat/test-preview-static.R
+++ b/tests/testthat/test-preview-static.R
@@ -1,0 +1,14 @@
+library(tabulatoR)
+
+testthat::skip_if_not_installed("shinytest2")
+library(shinytest2)
+
+test_that("preview_static renders data", {
+    app <- AppDriver$new(preview_static())
+    on.exit(app$stop())
+
+    app$wait_for_js("window.static_table !== undefined", timeout = 5000)
+    rows <- app$get_js("window.static_table.getDataCount();")
+    expect_equal(rows, 6)
+})
+


### PR DESCRIPTION
## Summary
- add `preview_static` function to launch a minimal Shiny table
- expose function in namespace and suggest shinytest2
- cover static preview with a shinytest2 test

## Testing
- `pkgload::load_all()` *(fails: there is no package called 'pkgload')*
- `install.packages("pkgload", repos="https://cloud.r-project.org")` *(fails: build from source triggered lengthy compilation and did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_689cd4896a0c83268a9d608cf6e8458d